### PR TITLE
[codex] Prepare DWaveNeal maintenance release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,11 @@ authors = [
     "Pedro Maciel Xavier <pedroxavier@psr-inc.com.br>",
     "David E. Bernal Neira <dbernaln@purdue.edu>",
 ]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 DWave = "4d534982-bf11-4157-9e48-fe3a62208a50"
 
 [compat]
-DWave = "0.5.2"
+DWave = "0.5.2, 0.6"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 
 
 [![DOI](https://zenodo.org/badge/506537248.svg)](https://zenodo.org/badge/latestdoi/506537248)
-[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/psrenergy/QUBODrivers.jl)
+[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/JuliaQUBO/QUBODrivers.jl)
 
 
 [D-Wave Neal](https://docs.ocean.dwavesys.com/projects/neal/en/latest/) compatibility layer for JuMP.
+
+## Maintenance status
+This package is maintained only as a compatibility shim for existing
+`DWaveNeal.jl` users. New sampler features, bug fixes, and interface work should
+happen in [DWave.jl](https://github.com/JuliaQUBO/DWave.jl).
 
 ## Installation
 ```julia


### PR DESCRIPTION
## Summary

Prepare `DWaveNeal.jl` as a maintenance-only compatibility shim release.

- bump the package version to `0.5.1`
- widen `DWave` compat to allow `0.6`, including the current `DWave v0.6.5` stack with `QUBODrivers v0.5.0`
- update the QUBODrivers badge link to the canonical `JuliaQUBO` repository
- document the maintenance-only status in the README

Closes #6.
Closes #7.

## Follow-up

CI modernization and TagBot workflow changes are intentionally left for a separate PR so the release commit does not modify `.github/workflows/*`. TagBot cannot reliably tag/release workflow-changing commits with `GITHUB_TOKEN`.

## Validation

- `julia --project=. -e 'import Pkg; Pkg.test()'`
  - Julia `1.10.11`
  - resolved `DWave v0.6.5` and `QUBODrivers v0.5.0`
  - QUBODrivers test suite: `139/139` passing
- `julia +release --project=. -e 'import Pkg; Pkg.test()'`
  - Julia `1.12.0`
  - resolved `DWave v0.6.5` and `QUBODrivers v0.5.0`
  - QUBODrivers test suite: `139/139` passing

The `DWAVE_API_TOKEN` warning is expected for the local classical sampler test path.